### PR TITLE
fix tpmc summary parser

### DIFF
--- a/helper/helper.bash
+++ b/helper/helper.bash
@@ -32,7 +32,7 @@ function parse_tpmc_summary()
             item = b[idx]
             if (item ~ "Sum" || item ~ "TPM") continue;
             split(item,pair,": ")
-            if (idx != 1) {
+            if (columns != "") {
                 columns = columns ","
                 values = values ","
             }


### PR DESCRIPTION
awk doesn't actually have indexed arrays, it only has associative arrays